### PR TITLE
Added ifndef checks to disable GLCD and/or U8G2 support

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -1,3 +1,11 @@
-#include "config/enable-glcd.h"         // Enable AltSerialGraphicLCD version of GEM
-#include "config/enable-u8g2.h"         // Enable U8g2 version of GEM
+// only include GLCD support, if the "dont use" define was not defined (can be defined ad project level).
+#ifndef GEM_DONT_USE_GLCD
+    #include "config/enable-glcd.h"         // Enable AltSerialGraphicLCD version of GEM
+#endif
+
+// only include U8G2 support, if the "dont use" define was not defined (can be defined ad project level).
+#ifndef GEM_DONT_USE_U8G2
+    #include "config/enable-u8g2.h"         // Enable U8g2 version of GEM
+#endif
+
 #include "config/support-float-edit.h"  // Support for editable float and double variables (option selects support them regardless of this setting)

--- a/src/config.h
+++ b/src/config.h
@@ -1,9 +1,9 @@
-// only include GLCD support, if the "dont use" define was not defined (can be defined ad project level).
+// Automatically enabled GLCD support. Can be disabled by adding the `GEM_DONT_USE_GLCD` define to your project level. 
 #ifndef GEM_DONT_USE_GLCD
     #include "config/enable-glcd.h"         // Enable AltSerialGraphicLCD version of GEM
 #endif
 
-// only include U8G2 support, if the "dont use" define was not defined (can be defined ad project level).
+// Automatically enabled U8G2 support. Can be disabled by adding the `GEM_DONT_USE_U8G2` define to your project level. 
 #ifndef GEM_DONT_USE_U8G2
     #include "config/enable-u8g2.h"         // Enable U8g2 version of GEM
 #endif


### PR DESCRIPTION
Added define check to be able to disable the GLCD or U8G2 support without the need to edit the configuration file at library level (normally, this change is not tracked and needs to be adjusted manually each time the project is set up). With this define level check, you are now able to suppress the GLCD or U8G2 support via compiler flag or by defining the define before the GEM header is included.