### PR TITLE
Const char

### DIFF
--- a/src/GEMItem.cpp
+++ b/src/GEMItem.cpp
@@ -257,7 +257,7 @@ GEMItem::GEMItem(const char* title_, int& linkedVariable_, GEMPage* linkedPage_)
 { }
 
 GEMItem::GEMItem(const char* title_, int& linkedVariable_, GEMPage& linkedPage_)
-  : GEMItem(title_, linkedVariable_, &linkedPage_) // call GEMPage* constructor
+  : GEMItem(title_, linkedVariable_, &linkedPage_) // call GEMItem* constructor
 { }
 
 GEMItem::GEMItem(const char* title_, char* linkedVariable_, GEMPage* linkedPage_)
@@ -270,7 +270,7 @@ GEMItem::GEMItem(const char* title_, char* linkedVariable_, GEMPage* linkedPage_
 { }
 
 GEMItem::GEMItem(const char* title_, char* linkedVariable_, GEMPage& linkedPage_)
-  : GEMItem(title_, linkedVariable_, &linkedPage_) // call GEMPage* constructor
+  : GEMItem(title_, linkedVariable_, &linkedPage_) // call GEMItem* constructor
 { }
 
 GEMItem::GEMItem(const char* title_, bool& linkedVariable_, GEMPage* linkedPage_)
@@ -283,7 +283,7 @@ GEMItem::GEMItem(const char* title_, bool& linkedVariable_, GEMPage* linkedPage_
 { }
 
 GEMItem::GEMItem(const char* title_, bool& linkedVariable_, GEMPage& linkedPage_)
-  : GEMItem(title_, linkedVariable_, &linkedPage_) // call GEMPage* constructor
+  : GEMItem(title_, linkedVariable_, &linkedPage_) // call GEMItem* constructor
 { }
 
 GEMItem::GEMItem(const char* title_, float& linkedVariable_, GEMPage* linkedPage_)
@@ -298,7 +298,7 @@ GEMItem::GEMItem(const char* title_, float& linkedVariable_, GEMPage* linkedPage
 
 
 GEMItem::GEMItem(const char* title_, float& linkedVariable_, GEMPage& linkedPage_)
-  : GEMItem(title_, linkedVariable_, &linkedPage_) // call GEMPage* constructor
+  : GEMItem(title_, linkedVariable_, &linkedPage_) // call GEMItem* constructor
 { }
 
 GEMItem::GEMItem(const char* title_, double& linkedVariable_, GEMPage* linkedPage_)

--- a/src/GEMItem.cpp
+++ b/src/GEMItem.cpp
@@ -312,7 +312,7 @@ GEMItem::GEMItem(const char* title_, double& linkedVariable_, GEMPage* linkedPag
 { }
 
 GEMItem::GEMItem(const char* title_, double& linkedVariable_, GEMPage& linkedPage_)
-  : GEMItem(title_, linkedVariable_, &linkedPage_) // call GEMPage* constructor
+  : GEMItem(title_, linkedVariable_, &linkedPage_) // call GEMItem* constructor
 { }
 
 //---

--- a/src/GEMItem.cpp
+++ b/src/GEMItem.cpp
@@ -36,7 +36,7 @@
 #include "GEMItem.h"
 #include "constants.h"
 
-GEMItem::GEMItem(char* title_, byte& linkedVariable_, GEMSelect& select_, void (*saveAction_)())
+GEMItem::GEMItem(const char* title_, byte& linkedVariable_, GEMSelect& select_, void (*saveAction_)())
   : title(title_)
   , linkedVariable(&linkedVariable_)
   , linkedType(GEM_VAL_SELECT)
@@ -45,7 +45,7 @@ GEMItem::GEMItem(char* title_, byte& linkedVariable_, GEMSelect& select_, void (
   , type(GEM_ITEM_VAL)
 { }
 
-GEMItem::GEMItem(char* title_, int& linkedVariable_, GEMSelect& select_, void (*saveAction_)())
+GEMItem::GEMItem(const char* title_, int& linkedVariable_, GEMSelect& select_, void (*saveAction_)())
   : title(title_)
   , linkedVariable(&linkedVariable_)
   , linkedType(GEM_VAL_SELECT)
@@ -54,7 +54,7 @@ GEMItem::GEMItem(char* title_, int& linkedVariable_, GEMSelect& select_, void (*
   , type(GEM_ITEM_VAL)
 { }
 
-GEMItem::GEMItem(char* title_, char* linkedVariable_, GEMSelect& select_, void (*saveAction_)())
+GEMItem::GEMItem(const char* title_, char* linkedVariable_, GEMSelect& select_, void (*saveAction_)())
   : title(title_)
   , linkedVariable(linkedVariable_)
   , linkedType(GEM_VAL_SELECT)
@@ -63,7 +63,7 @@ GEMItem::GEMItem(char* title_, char* linkedVariable_, GEMSelect& select_, void (
   , type(GEM_ITEM_VAL)
 { }
 
-GEMItem::GEMItem(char* title_, float& linkedVariable_, GEMSelect& select_, void (*saveAction_)())
+GEMItem::GEMItem(const char* title_, float& linkedVariable_, GEMSelect& select_, void (*saveAction_)())
   : title(title_)
   , linkedVariable(&linkedVariable_)
   , linkedType(GEM_VAL_SELECT)
@@ -72,7 +72,7 @@ GEMItem::GEMItem(char* title_, float& linkedVariable_, GEMSelect& select_, void 
   , type(GEM_ITEM_VAL)
 { }
 
-GEMItem::GEMItem(char* title_, double& linkedVariable_, GEMSelect& select_, void (*saveAction_)())
+GEMItem::GEMItem(const char* title_, double& linkedVariable_, GEMSelect& select_, void (*saveAction_)())
   : title(title_)
   , linkedVariable(&linkedVariable_)
   , linkedType(GEM_VAL_SELECT)
@@ -83,7 +83,7 @@ GEMItem::GEMItem(char* title_, double& linkedVariable_, GEMSelect& select_, void
 
 //---
 
-GEMItem::GEMItem(char* title_, byte& linkedVariable_, GEMSelect& select_, bool readonly_)
+GEMItem::GEMItem(const char* title_, byte& linkedVariable_, GEMSelect& select_, bool readonly_)
   : title(title_)
   , linkedVariable(&linkedVariable_)
   , linkedType(GEM_VAL_SELECT)
@@ -92,7 +92,7 @@ GEMItem::GEMItem(char* title_, byte& linkedVariable_, GEMSelect& select_, bool r
   , type(GEM_ITEM_VAL)
 { }
 
-GEMItem::GEMItem(char* title_, int& linkedVariable_, GEMSelect& select_, bool readonly_)
+GEMItem::GEMItem(const char* title_, int& linkedVariable_, GEMSelect& select_, bool readonly_)
   : title(title_)
   , linkedVariable(&linkedVariable_)
   , linkedType(GEM_VAL_SELECT)
@@ -101,7 +101,7 @@ GEMItem::GEMItem(char* title_, int& linkedVariable_, GEMSelect& select_, bool re
   , type(GEM_ITEM_VAL)
 { }
 
-GEMItem::GEMItem(char* title_, char* linkedVariable_, GEMSelect& select_, bool readonly_)
+GEMItem::GEMItem(const char* title_, char* linkedVariable_, GEMSelect& select_, bool readonly_)
   : title(title_)
   , linkedVariable(linkedVariable_)
   , linkedType(GEM_VAL_SELECT)
@@ -110,7 +110,7 @@ GEMItem::GEMItem(char* title_, char* linkedVariable_, GEMSelect& select_, bool r
   , type(GEM_ITEM_VAL)
 { }
 
-GEMItem::GEMItem(char* title_, float& linkedVariable_, GEMSelect& select_, bool readonly_)
+GEMItem::GEMItem(const char* title_, float& linkedVariable_, GEMSelect& select_, bool readonly_)
   : title(title_)
   , linkedVariable(&linkedVariable_)
   , linkedType(GEM_VAL_SELECT)
@@ -119,7 +119,7 @@ GEMItem::GEMItem(char* title_, float& linkedVariable_, GEMSelect& select_, bool 
   , type(GEM_ITEM_VAL)
 { }
 
-GEMItem::GEMItem(char* title_, double& linkedVariable_, GEMSelect& select_, bool readonly_)
+GEMItem::GEMItem(const char* title_, double& linkedVariable_, GEMSelect& select_, bool readonly_)
   : title(title_)
   , linkedVariable(&linkedVariable_)
   , linkedType(GEM_VAL_SELECT)
@@ -130,7 +130,7 @@ GEMItem::GEMItem(char* title_, double& linkedVariable_, GEMSelect& select_, bool
 
 //---
 
-GEMItem::GEMItem(char* title_, byte& linkedVariable_, void (*saveAction_)())
+GEMItem::GEMItem(const char* title_, byte& linkedVariable_, void (*saveAction_)())
   : title(title_)
   , linkedVariable(&linkedVariable_)
   , linkedType(GEM_VAL_BYTE)
@@ -138,7 +138,7 @@ GEMItem::GEMItem(char* title_, byte& linkedVariable_, void (*saveAction_)())
   , saveAction(saveAction_)
 { }
 
-GEMItem::GEMItem(char* title_, int& linkedVariable_, void (*saveAction_)())
+GEMItem::GEMItem(const char* title_, int& linkedVariable_, void (*saveAction_)())
   : title(title_)
   , linkedVariable(&linkedVariable_)
   , linkedType(GEM_VAL_INTEGER)
@@ -146,7 +146,7 @@ GEMItem::GEMItem(char* title_, int& linkedVariable_, void (*saveAction_)())
   , saveAction(saveAction_)
 { }
 
-GEMItem::GEMItem(char* title_, char* linkedVariable_, void (*saveAction_)())
+GEMItem::GEMItem(const char* title_, char* linkedVariable_, void (*saveAction_)())
   : title(title_)
   , linkedVariable(linkedVariable_)
   , linkedType(GEM_VAL_CHAR)
@@ -154,7 +154,7 @@ GEMItem::GEMItem(char* title_, char* linkedVariable_, void (*saveAction_)())
   , saveAction(saveAction_)
 { }
 
-GEMItem::GEMItem(char* title_, bool& linkedVariable_, void (*saveAction_)())
+GEMItem::GEMItem(const char* title_, bool& linkedVariable_, void (*saveAction_)())
   : title(title_)
   , linkedVariable(&linkedVariable_)
   , linkedType(GEM_VAL_BOOL)
@@ -162,7 +162,7 @@ GEMItem::GEMItem(char* title_, bool& linkedVariable_, void (*saveAction_)())
   , saveAction(saveAction_)
 { }
 
-GEMItem::GEMItem(char* title_, float& linkedVariable_, void (*saveAction_)())
+GEMItem::GEMItem(const char* title_, float& linkedVariable_, void (*saveAction_)())
   : title(title_)
   , linkedVariable(&linkedVariable_)
   , linkedType(GEM_VAL_FLOAT)
@@ -171,7 +171,7 @@ GEMItem::GEMItem(char* title_, float& linkedVariable_, void (*saveAction_)())
   , saveAction(saveAction_)
 { }
 
-GEMItem::GEMItem(char* title_, double& linkedVariable_, void (*saveAction_)())
+GEMItem::GEMItem(const char* title_, double& linkedVariable_, void (*saveAction_)())
   : title(title_)
   , linkedVariable(&linkedVariable_)
   , linkedType(GEM_VAL_DOUBLE)
@@ -182,7 +182,7 @@ GEMItem::GEMItem(char* title_, double& linkedVariable_, void (*saveAction_)())
 
 //---
 
-GEMItem::GEMItem(char* title_, byte& linkedVariable_, bool readonly_)
+GEMItem::GEMItem(const char* title_, byte& linkedVariable_, bool readonly_)
   : title(title_)
   , linkedVariable(&linkedVariable_)
   , linkedType(GEM_VAL_BYTE)
@@ -190,7 +190,7 @@ GEMItem::GEMItem(char* title_, byte& linkedVariable_, bool readonly_)
   , type(GEM_ITEM_VAL)
 { }
 
-GEMItem::GEMItem(char* title_, int& linkedVariable_, bool readonly_)
+GEMItem::GEMItem(const char* title_, int& linkedVariable_, bool readonly_)
   : title(title_)
   , linkedVariable(&linkedVariable_)
   , linkedType(GEM_VAL_INTEGER)
@@ -198,7 +198,7 @@ GEMItem::GEMItem(char* title_, int& linkedVariable_, bool readonly_)
   , type(GEM_ITEM_VAL)
 { }
 
-GEMItem::GEMItem(char* title_, char* linkedVariable_, bool readonly_)
+GEMItem::GEMItem(const char* title_, char* linkedVariable_, bool readonly_)
   : title(title_)
   , linkedVariable(linkedVariable_)
   , linkedType(GEM_VAL_CHAR)
@@ -206,7 +206,7 @@ GEMItem::GEMItem(char* title_, char* linkedVariable_, bool readonly_)
   , type(GEM_ITEM_VAL)
 { }
 
-GEMItem::GEMItem(char* title_, bool& linkedVariable_, bool readonly_)
+GEMItem::GEMItem(const char* title_, bool& linkedVariable_, bool readonly_)
   : title(title_)
   , linkedVariable(&linkedVariable_)
   , linkedType(GEM_VAL_BOOL)
@@ -214,7 +214,7 @@ GEMItem::GEMItem(char* title_, bool& linkedVariable_, bool readonly_)
   , type(GEM_ITEM_VAL)
 { }
 
-GEMItem::GEMItem(char* title_, float& linkedVariable_, bool readonly_)
+GEMItem::GEMItem(const char* title_, float& linkedVariable_, bool readonly_)
   : title(title_)
   , linkedVariable(&linkedVariable_)
   , linkedType(GEM_VAL_FLOAT)
@@ -223,7 +223,7 @@ GEMItem::GEMItem(char* title_, float& linkedVariable_, bool readonly_)
   , type(GEM_ITEM_VAL)
 { }
 
-GEMItem::GEMItem(char* title_, double& linkedVariable_, bool readonly_)
+GEMItem::GEMItem(const char* title_, double& linkedVariable_, bool readonly_)
   : title(title_)
   , linkedVariable(&linkedVariable_)
   , linkedType(GEM_VAL_DOUBLE)
@@ -234,7 +234,7 @@ GEMItem::GEMItem(char* title_, double& linkedVariable_, bool readonly_)
 
 //---
 
-GEMItem::GEMItem(char* title_, byte& linkedVariable_, GEMPage* linkedPage_)
+GEMItem::GEMItem(const char* title_, byte& linkedVariable_, GEMPage* linkedPage_)
   : title(title_)
   , linkedVariable(&linkedVariable_)
   , linkedPage(linkedPage_)
@@ -243,11 +243,11 @@ GEMItem::GEMItem(char* title_, byte& linkedVariable_, GEMPage* linkedPage_)
   , type(GEM_ITEM_LINKED_VAL)
 { }
 
-GEMItem::GEMItem(char* title_, byte& linkedVariable_, GEMPage& linkedPage_)
-  : GEMItem(title_, linkedVariable_, &linkedPage_) // call GEMItem* constructor
+GEMItem::GEMItem(const char* title_, byte& linkedVariable_, GEMPage& linkedPage_)
+  : GEMItem(title_, linkedVariable_, &linkedPage_) // call GEMPage* constructor
 { }
 
-GEMItem::GEMItem(char* title_, int& linkedVariable_, GEMPage* linkedPage_)
+GEMItem::GEMItem(const char* title_, int& linkedVariable_, GEMPage* linkedPage_)
   : title(title_)
   , linkedVariable(&linkedVariable_)
   , linkedPage(linkedPage_)
@@ -256,11 +256,11 @@ GEMItem::GEMItem(char* title_, int& linkedVariable_, GEMPage* linkedPage_)
   , type(GEM_ITEM_LINKED_VAL)
 { }
 
-GEMItem::GEMItem(char* title_, int& linkedVariable_, GEMPage& linkedPage_)
+GEMItem::GEMItem(const char* title_, int& linkedVariable_, GEMPage& linkedPage_)
   : GEMItem(title_, linkedVariable_, &linkedPage_) // call GEMPage* constructor
 { }
 
-GEMItem::GEMItem(char* title_, char* linkedVariable_, GEMPage* linkedPage_)
+GEMItem::GEMItem(const char* title_, char* linkedVariable_, GEMPage* linkedPage_)
   : title(title_)
   , linkedVariable(linkedVariable_)
   , linkedPage(linkedPage_)
@@ -269,11 +269,11 @@ GEMItem::GEMItem(char* title_, char* linkedVariable_, GEMPage* linkedPage_)
   , type(GEM_ITEM_LINKED_VAL)
 { }
 
-GEMItem::GEMItem(char* title_, char* linkedVariable_, GEMPage& linkedPage_)
+GEMItem::GEMItem(const char* title_, char* linkedVariable_, GEMPage& linkedPage_)
   : GEMItem(title_, linkedVariable_, &linkedPage_) // call GEMPage* constructor
 { }
 
-GEMItem::GEMItem(char* title_, bool& linkedVariable_, GEMPage* linkedPage_)
+GEMItem::GEMItem(const char* title_, bool& linkedVariable_, GEMPage* linkedPage_)
   : title(title_)
   , linkedVariable(&linkedVariable_)
   , linkedPage(linkedPage_)
@@ -282,11 +282,11 @@ GEMItem::GEMItem(char* title_, bool& linkedVariable_, GEMPage* linkedPage_)
   , type(GEM_ITEM_LINKED_VAL)
 { }
 
-GEMItem::GEMItem(char* title_, bool& linkedVariable_, GEMPage& linkedPage_)
+GEMItem::GEMItem(const char* title_, bool& linkedVariable_, GEMPage& linkedPage_)
   : GEMItem(title_, linkedVariable_, &linkedPage_) // call GEMPage* constructor
 { }
 
-GEMItem::GEMItem(char* title_, float& linkedVariable_, GEMPage* linkedPage_)
+GEMItem::GEMItem(const char* title_, float& linkedVariable_, GEMPage* linkedPage_)
   : title(title_)
   , linkedVariable(&linkedVariable_)
   , linkedPage(linkedPage_)
@@ -297,11 +297,11 @@ GEMItem::GEMItem(char* title_, float& linkedVariable_, GEMPage* linkedPage_)
 { }
 
 
-GEMItem::GEMItem(char* title_, float& linkedVariable_, GEMPage& linkedPage_)
+GEMItem::GEMItem(const char* title_, float& linkedVariable_, GEMPage& linkedPage_)
   : GEMItem(title_, linkedVariable_, &linkedPage_) // call GEMPage* constructor
 { }
 
-GEMItem::GEMItem(char* title_, double& linkedVariable_, GEMPage* linkedPage_)
+GEMItem::GEMItem(const char* title_, double& linkedVariable_, GEMPage* linkedPage_)
   : title(title_)
   , linkedVariable(&linkedVariable_)
   , linkedPage(linkedPage_)
@@ -311,38 +311,46 @@ GEMItem::GEMItem(char* title_, double& linkedVariable_, GEMPage* linkedPage_)
   , type(GEM_ITEM_LINKED_VAL)
 { }
 
-GEMItem::GEMItem(char* title_, double& linkedVariable_, GEMPage& linkedPage_)
+GEMItem::GEMItem(const char* title_, double& linkedVariable_, GEMPage& linkedPage_)
   : GEMItem(title_, linkedVariable_, &linkedPage_) // call GEMPage* constructor
 { }
 
 //---
 
-GEMItem::GEMItem(char* title_, GEMPage& linkedPage_, bool readonly_)
+GEMItem::GEMItem(const char* title_, GEMPage& linkedPage_, bool readonly_)
   : title(title_)
   , linkedPage(&linkedPage_)
   , readonly(readonly_)
   , type(GEM_ITEM_LINK)
 { }
 
-GEMItem::GEMItem(char* title_, GEMPage* linkedPage_, bool readonly_)
+GEMItem::GEMItem(const char* title_, GEMPage* linkedPage_, bool readonly_)
   : title(title_)
   , linkedPage(linkedPage_)
   , readonly(readonly_)
   , type(GEM_ITEM_LINK)
 { }
 
-GEMItem::GEMItem(char* title_, void (*buttonAction_)(), bool readonly_)
+GEMItem::GEMItem(const char* title_, void (*buttonAction_)(), bool readonly_)
   : title(title_)
   , buttonAction(buttonAction_)
   , readonly(readonly_)
   , type(GEM_ITEM_BUTTON)
 { }
 
-void GEMItem::setTitle(char* title_) {
+GEMItem::GEMItem(const __FlashStringHelper* title_) {
+    return GEMItem(title_->c_str());
+}
+
+GEMItem::GEMItem(const __FlashStringHelper* title_, const char *fmt...) {
+    return GEMItem(title_->c_str(), fmt);
+}
+
+void GEMItem::setTitle(const char* title_) {
   title = title_;
 }
 
-char* GEMItem::getTitle() {
+const char* GEMItem::getTitle() {
   return title;
 }
 

--- a/src/GEMItem.cpp
+++ b/src/GEMItem.cpp
@@ -244,7 +244,7 @@ GEMItem::GEMItem(const char* title_, byte& linkedVariable_, GEMPage* linkedPage_
 { }
 
 GEMItem::GEMItem(const char* title_, byte& linkedVariable_, GEMPage& linkedPage_)
-  : GEMItem(title_, linkedVariable_, &linkedPage_) // call GEMPage* constructor
+  : GEMItem(title_, linkedVariable_, &linkedPage_) // call GEMItem* constructor
 { }
 
 GEMItem::GEMItem(const char* title_, int& linkedVariable_, GEMPage* linkedPage_)

--- a/src/GEMItem.cpp
+++ b/src/GEMItem.cpp
@@ -338,12 +338,8 @@ GEMItem::GEMItem(const char* title_, void (*buttonAction_)(), bool readonly_)
   , type(GEM_ITEM_BUTTON)
 { }
 
-GEMItem::GEMItem(const __FlashStringHelper* title_) {
-    return GEMItem(title_->c_str());
-}
-
-GEMItem::GEMItem(const __FlashStringHelper* title_, const char *fmt...) {
-    return GEMItem(title_->c_str(), fmt);
+template<typename... Args> GEMItem::GEMItem(const __FlashStringHelper* title_, Args... args) :
+  GEMItem(reinterpret_cast<PGM_P>(title_), args...) {
 }
 
 void GEMItem::setTitle(const char* title_) {

--- a/src/GEMItem.h
+++ b/src/GEMItem.h
@@ -32,18 +32,21 @@
   along with this library.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "constants.h"
+#include <fmt/format.h>  // for "const char* fmt, ..."
+#include <WString.h>     // for __FlashStringHelper (F("asd"))
+
 #include "GEMPage.h"
+#include "constants.h"
 
 #ifndef HEADER_GEMITEM
 #define HEADER_GEMITEM
 
 // Macro constants (aliases) for menu item types
-#define GEM_ITEM_VAL 0        // Menu item represents associated variable
-#define GEM_ITEM_LINK 1       // Menu item represents link to another menu page
-#define GEM_ITEM_BACK 2       // Menu item represents Back button (that links to parent level menu page)
-#define GEM_ITEM_BUTTON 3     // Menu item represents button (that leads to execution of user-defined routine in its own context)
-#define GEM_ITEM_LINKED_VAL 4 // Menu item represents a value that is linked to another menu page
+#define GEM_ITEM_VAL 0         // Menu item represents associated variable
+#define GEM_ITEM_LINK 1        // Menu item represents link to another menu page
+#define GEM_ITEM_BACK 2        // Menu item represents Back button (that links to parent level menu page)
+#define GEM_ITEM_BUTTON 3      // Menu item represents button (that leads to execution of user-defined routine in its own context)
+#define GEM_ITEM_LINKED_VAL 4  // Menu item represents a value that is linked to another menu page
 
 // Macro constant (alias) for readonly modifier of associated with menu item variable
 #define GEM_READONLY true
@@ -60,6 +63,7 @@ class GEMItem {
   friend class GEM;
   friend class GEM_u8g2;
   friend class GEMPage;
+
   public:
     /* 
       Constructors for menu item that represents option select, w/ callback
@@ -68,11 +72,11 @@ class GEMItem {
       @param 'select_' - reference to GEMSelect option select
       @param 'saveAction_' - pointer to callback function executed when associated variable is successfully saved
     */
-    GEMItem(char* title_, byte& linkedVariable_, GEMSelect& select_, void (*saveAction_)());
-    GEMItem(char* title_, int& linkedVariable_, GEMSelect& select_, void (*saveAction_)());
-    GEMItem(char* title_, char* linkedVariable_, GEMSelect& select_, void (*saveAction_)());
-    GEMItem(char* title_, float& linkedVariable_, GEMSelect& select_, void (*saveAction_)());
-    GEMItem(char* title_, double& linkedVariable_, GEMSelect& select_, void (*saveAction_)());
+    GEMItem(const char* title_, byte& linkedVariable_, GEMSelect& select_, void (*saveAction_)());
+    GEMItem(const char* title_, int& linkedVariable_, GEMSelect& select_, void (*saveAction_)());
+    GEMItem(const char* title_, char* linkedVariable_, GEMSelect& select_, void (*saveAction_)());
+    GEMItem(const char* title_, float& linkedVariable_, GEMSelect& select_, void (*saveAction_)());
+    GEMItem(const char* title_, double& linkedVariable_, GEMSelect& select_, void (*saveAction_)());
     /* 
       Constructors for menu item that represents option select, w/o callback
       @param 'title_' - title of the menu item displayed on the screen
@@ -82,23 +86,23 @@ class GEMItem {
       values GEM_READONLY (alias for true)
       default false
     */
-    GEMItem(char* title_, byte& linkedVariable_, GEMSelect& select_, bool readonly_ = false);
-    GEMItem(char* title_, int& linkedVariable_, GEMSelect& select_, bool readonly_ = false);
-    GEMItem(char* title_, char* linkedVariable_, GEMSelect& select_, bool readonly_ = false);
-    GEMItem(char* title_, float& linkedVariable_, GEMSelect& select_, bool readonly_ = false);
-    GEMItem(char* title_, double& linkedVariable_, GEMSelect& select_, bool readonly_ = false);
+    GEMItem(const char* title_, byte& linkedVariable_, GEMSelect& select_, bool readonly_ = false);
+    GEMItem(const char* title_, int& linkedVariable_, GEMSelect& select_, bool readonly_ = false);
+    GEMItem(const char* title_, char* linkedVariable_, GEMSelect& select_, bool readonly_ = false);
+    GEMItem(const char* title_, float& linkedVariable_, GEMSelect& select_, bool readonly_ = false);
+    GEMItem(const char* title_, double& linkedVariable_, GEMSelect& select_, bool readonly_ = false);
     /* 
       Constructors for menu item that represents variable, w/ callback
       @param 'title_' - title of the menu item displayed on the screen
       @param 'linkedVariable_' - reference to variable that menu item is associated with (either byte, int, char*, bool, float, or double)
       @param 'saveAction_' - pointer to callback function executed when associated variable is successfully saved
     */
-    GEMItem(char* title_, byte& linkedVariable_, void (*saveAction_)());
-    GEMItem(char* title_, int& linkedVariable_, void (*saveAction_)());
-    GEMItem(char* title_, char* linkedVariable_, void (*saveAction_)());
-    GEMItem(char* title_, bool& linkedVariable_, void (*saveAction_)());
-    GEMItem(char* title_, float& linkedVariable_, void (*saveAction_)());
-    GEMItem(char* title_, double& linkedVariable_, void (*saveAction_)());
+    GEMItem(const char* title_, byte& linkedVariable_, void (*saveAction_)());
+    GEMItem(const char* title_, int& linkedVariable_, void (*saveAction_)());
+    GEMItem(const char* title_, char* linkedVariable_, void (*saveAction_)());
+    GEMItem(const char* title_, bool& linkedVariable_, void (*saveAction_)());
+    GEMItem(const char* title_, float& linkedVariable_, void (*saveAction_)());
+    GEMItem(const char* title_, double& linkedVariable_, void (*saveAction_)());
     /* 
       Constructors for menu item that represents variable, w/o callback
       @param 'title_' - title of the menu item displayed on the screen
@@ -107,30 +111,30 @@ class GEMItem {
       values GEM_READONLY (alias for true)
       default false
     */
-    GEMItem(char* title_, byte& linkedVariable_, bool readonly_ = false);
-    GEMItem(char* title_, int& linkedVariable_, bool readonly_ = false);
-    GEMItem(char* title_, char* linkedVariable_, bool readonly_ = false);
-    GEMItem(char* title_, bool& linkedVariable_, bool readonly_ = false);
-    GEMItem(char* title_, float& linkedVariable_, bool readonly_ = false);
-    GEMItem(char* title_, double& linkedVariable_, bool readonly_ = false);
+    GEMItem(const char* title_, byte& linkedVariable_, bool readonly_ = false);
+    GEMItem(const char* title_, int& linkedVariable_, bool readonly_ = false);
+    GEMItem(const char* title_, char* linkedVariable_, bool readonly_ = false);
+    GEMItem(const char* title_, bool& linkedVariable_, bool readonly_ = false);
+    GEMItem(const char* title_, float& linkedVariable_, bool readonly_ = false);
+    GEMItem(const char* title_, double& linkedVariable_, bool readonly_ = false);
     /* 
       Constructors for menu item that represents variable, that are linked to another screen
       @param 'title_' - title of the menu item displayed on the screen
       @param 'linkedVariable_' - reference to variable that menu item is associated with (either byte, int, char*, bool, float, or double)
       @param 'linkedPage_' - reference to GEMPage menu page that menu item is associated with
       */
-    GEMItem(char* title_, byte& linkedVariable_, GEMPage* linkedPage_);
-    GEMItem(char* title_, byte& linkedVariable_, GEMPage& linkedPage_);
-    GEMItem(char* title_, int& linkedVariable_, GEMPage* linkedPage_);
-    GEMItem(char* title_, int& linkedVariable_, GEMPage& linkedPage_);
-    GEMItem(char* title_, char* linkedVariable_, GEMPage* linkedPage_);
-    GEMItem(char* title_, char* linkedVariable_, GEMPage& linkedPage_);
-    GEMItem(char* title_, bool& linkedVariable_, GEMPage* linkedPage_);
-    GEMItem(char* title_, bool& linkedVariable_, GEMPage& linkedPage_);
-    GEMItem(char* title_, float& linkedVariable_, GEMPage* linkedPage_);
-    GEMItem(char* title_, float& linkedVariable_, GEMPage& linkedPage_);
-    GEMItem(char* title_, double& linkedVariable_, GEMPage* linkedPage_);
-    GEMItem(char* title_, double& linkedVariable_, GEMPage& linkedPage_);
+    GEMItem(const char* title_, byte& linkedVariable_, GEMPage* linkedPage_);
+    GEMItem(const char* title_, byte& linkedVariable_, GEMPage& linkedPage_);
+    GEMItem(const char* title_, int& linkedVariable_, GEMPage* linkedPage_);
+    GEMItem(const char* title_, int& linkedVariable_, GEMPage& linkedPage_);
+    GEMItem(const char* title_, char* linkedVariable_, GEMPage* linkedPage_);
+    GEMItem(const char* title_, char* linkedVariable_, GEMPage& linkedPage_);
+    GEMItem(const char* title_, bool& linkedVariable_, GEMPage* linkedPage_);
+    GEMItem(const char* title_, bool& linkedVariable_, GEMPage& linkedPage_);
+    GEMItem(const char* title_, float& linkedVariable_, GEMPage* linkedPage_);
+    GEMItem(const char* title_, float& linkedVariable_, GEMPage& linkedPage_);
+    GEMItem(const char* title_, double& linkedVariable_, GEMPage* linkedPage_);
+    GEMItem(const char* title_, double& linkedVariable_, GEMPage& linkedPage_);
     /* 
       Constructor for menu item that represents link to another menu page (via reference)
       @param 'title_' - title of the menu item displayed on the screen
@@ -138,7 +142,7 @@ class GEMItem {
       @param 'readonly_' (optional) - set readonly mode for the link (user won't be able to navigate to linked page)
       values GEM_READONLY (alias for true)
     */
-    GEMItem(char* title_, GEMPage& linkedPage_, bool readonly_ = false);
+    GEMItem(const char* title_, GEMPage& linkedPage_, bool readonly_ = false);
     /* 
       Constructor for menu item that represents link to another menu page (via pointer)
       @param 'title_' - title of the menu item displayed on the screen
@@ -146,7 +150,7 @@ class GEMItem {
       @param 'readonly_' (optional) - set readonly mode for the link (user won't be able to navigate to linked page)
       values GEM_READONLY (alias for true)
     */
-    GEMItem(char* title_, GEMPage* linkedPage_, bool readonly_ = false);
+    GEMItem(const char* title_, GEMPage* linkedPage_, bool readonly_ = false);
     /* 
       Constructor for menu item that represents button
       @param 'title_' - title of the menu item displayed on the screen
@@ -154,9 +158,16 @@ class GEMItem {
       @param 'readonly_' (optional) - set readonly mode for the button (user won't be able to call action associated with it)
       values GEM_READONLY (alias for true)
     */
-    GEMItem(char* title_, void (*buttonAction_)(), bool readonly_ = false);
+    GEMItem(const char* title_, void (*buttonAction_)(), bool readonly_ = false);
+
+    /*
+      Provide any GEMItem constructor with __FlashStringHelper (for F("asd") macro) instead of char* title.
+    */
+    GEMItem(const __FlashStringHelper* title_);
+    GEMItem(const __FlashStringHelper* title_, const char* fmt...);
+
     void setTitle(char* title_);            // Set title of the menu item
-    char* getTitle();                       // Get title of the menu item
+    const char* getTitle();                       // Get title of the menu item
     void setPrecision(byte prec);           // Explicitly set precision for float or double variables as required by dtostrf() conversion,
                                             // i.e. the number of digits after the decimal sign
     void setReadonly(bool mode = true);  // Explicitly set or unset readonly mode for variable that menu item is associated with
@@ -167,8 +178,9 @@ class GEMItem {
     void hide(bool hide = true);         // Explicitly hide or show menu item
     void show();                            // Explicitly show menu item
     bool getHidden();                    // Get hidden state of the menu item
+
   private:
-    char* title;
+    const char* title;
     byte type;
     void* linkedVariable;
     byte linkedType;

--- a/src/GEMItem.h
+++ b/src/GEMItem.h
@@ -32,7 +32,6 @@
   along with this library.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <fmt/format.h>  // for "const char* fmt, ..."
 #include <WString.h>     // for __FlashStringHelper (F("asd"))
 
 #include "GEMPage.h"
@@ -163,10 +162,9 @@ class GEMItem {
     /*
       Provide any GEMItem constructor with __FlashStringHelper (for F("asd") macro) instead of char* title.
     */
-    GEMItem(const __FlashStringHelper* title_);
-    GEMItem(const __FlashStringHelper* title_, const char* fmt...);
+    template<typename... Args> GEMItem(const __FlashStringHelper* title_, Args... args);
 
-    void setTitle(char* title_);            // Set title of the menu item
+    void setTitle(const char* title_);            // Set title of the menu item
     const char* getTitle();                       // Get title of the menu item
     void setPrecision(byte prec);           // Explicitly set precision for float or double variables as required by dtostrf() conversion,
                                             // i.e. the number of digits after the decimal sign

--- a/src/GEMPage.cpp
+++ b/src/GEMPage.cpp
@@ -41,7 +41,7 @@ GEMPage::GEMPage(const char* title_, void (*exitAction_)())
 { }
 
 GEMPage::GEMPage(const __FlashStringHelper* title_, void (*exitAction_)())
-    : title(title_->c_str())
+    : title(reinterpret_cast<PGM_P>(title_))
     , exitAction(exitAction_)
 { }
 

--- a/src/GEMPage.cpp
+++ b/src/GEMPage.cpp
@@ -48,19 +48,19 @@ GEMPage::GEMPage(const __FlashStringHelper* title_, void (*exitAction_)())
 void GEMPage::addMenuItem(GEMItem& menuItem) {
   // Prevent adding menu item that was already added to another (or the same) page
   if (menuItem.parentPage == nullptr) {
-      if (itemsCountTotal == 0) {
-          // If menu page is empty, link supplied menu item from within page directly (this will be the first menu item in a page)
-          _menuItem = &menuItem;
-      } else {
-          // If menu page is not empty, link supplied menu item from within the last menu item of the page
-          getMenuItem(itemsCountTotal-1, true)->menuItemNext = &menuItem;
-      }
-      menuItem.parentPage = this;
-      if (!menuItem.hidden) {
-          itemsCount++;
-      }
-      itemsCountTotal++;
-      currentItemNum = (_menuItemBack.linkedPage != nullptr) ? 1 : 0;
+    if (itemsCountTotal == 0) {
+        // If menu page is empty, link supplied menu item from within page directly (this will be the first menu item in a page)
+        _menuItem = &menuItem;
+    } else {
+        // If menu page is not empty, link supplied menu item from within the last menu item of the page
+        getMenuItem(itemsCountTotal-1, true)->menuItemNext = &menuItem;
+    }
+    menuItem.parentPage = this;
+    if (!menuItem.hidden) {
+        itemsCount++;
+    }
+    itemsCountTotal++;
+    currentItemNum = (_menuItemBack.linkedPage != nullptr) ? 1 : 0;
   }
 }
 
@@ -101,10 +101,10 @@ GEMItem* GEMPage::getCurrentMenuItem() {
 int GEMPage::getMenuItemNum(GEMItem& menuItem) {
   GEMItem* menuItemTmp = (_menuItem->hidden) ? _menuItem->getMenuItemNext() : _menuItem;
   for (byte i=0; i<itemsCount; i++) {
-      if (menuItemTmp == &menuItem) {
-          return i;
-      }
-      menuItemTmp = menuItemTmp->getMenuItemNext();
+    if (menuItemTmp == &menuItem) {
+        return i;
+    }
+    menuItemTmp = menuItemTmp->getMenuItemNext();
   }
   return -1;
 }
@@ -114,12 +114,12 @@ void GEMPage::hideMenuItem(GEMItem& menuItem) {
   menuItem.hidden = true;
   itemsCount--;
   if (menuItemNum <= currentItemNum) {
-      if (currentItemNum > 0) {
-          currentItemNum--;
-      }
+    if (currentItemNum > 0) {
+        currentItemNum--;
+    }
   }
   if (_menuItemBack.linkedPage != nullptr && itemsCount == 1) {
-      currentItemNum = 0;
+    currentItemNum = 0;
   }
 }
 

--- a/src/GEMPage.cpp
+++ b/src/GEMPage.cpp
@@ -36,8 +36,8 @@
 #include "GEMPage.h"
 
 GEMPage::GEMPage(const char* title_, void (*exitAction_)())
-    : title(title_)
-    , exitAction(exitAction_)
+  : title(title_)
+  , exitAction(exitAction_)
 { }
 
 GEMPage::GEMPage(const __FlashStringHelper* title_, void (*exitAction_)())
@@ -46,93 +46,93 @@ GEMPage::GEMPage(const __FlashStringHelper* title_, void (*exitAction_)())
 { }
 
 void GEMPage::addMenuItem(GEMItem& menuItem) {
-    // Prevent adding menu item that was already added to another (or the same) page
-    if (menuItem.parentPage == nullptr) {
-        if (itemsCountTotal == 0) {
-            // If menu page is empty, link supplied menu item from within page directly (this will be the first menu item in a page)
-            _menuItem = &menuItem;
-        } else {
-            // If menu page is not empty, link supplied menu item from within the last menu item of the page
-            getMenuItem(itemsCountTotal-1, true)->menuItemNext = &menuItem;
-        }
-        menuItem.parentPage = this;
-        if (!menuItem.hidden) {
-            itemsCount++;
-        }
-        itemsCountTotal++;
-        currentItemNum = (_menuItemBack.linkedPage != nullptr) ? 1 : 0;
-    }
+  // Prevent adding menu item that was already added to another (or the same) page
+  if (menuItem.parentPage == nullptr) {
+      if (itemsCountTotal == 0) {
+          // If menu page is empty, link supplied menu item from within page directly (this will be the first menu item in a page)
+          _menuItem = &menuItem;
+      } else {
+          // If menu page is not empty, link supplied menu item from within the last menu item of the page
+          getMenuItem(itemsCountTotal-1, true)->menuItemNext = &menuItem;
+      }
+      menuItem.parentPage = this;
+      if (!menuItem.hidden) {
+          itemsCount++;
+      }
+      itemsCountTotal++;
+      currentItemNum = (_menuItemBack.linkedPage != nullptr) ? 1 : 0;
+  }
 }
 
 void GEMPage::setParentMenuPage(GEMPage& parentMenuPage) {
-    _menuItemBack.type = GEM_ITEM_BACK;
-    _menuItemBack.linkedPage = &parentMenuPage;
-    // Back button menu item should be always inserted at first position in list
-    GEMItem* menuItemTmp = _menuItem;
-    _menuItem = &_menuItemBack;
-    if (menuItemTmp != 0) {
-        _menuItemBack.menuItemNext = menuItemTmp;
-    }
-    itemsCount++;
-    itemsCountTotal++;
-    currentItemNum = (itemsCount > 1) ? 1 : 0;
+  _menuItemBack.type = GEM_ITEM_BACK;
+  _menuItemBack.linkedPage = &parentMenuPage;
+  // Back button menu item should be always inserted at first position in list
+  GEMItem* menuItemTmp = _menuItem;
+  _menuItem = &_menuItemBack;
+  if (menuItemTmp != 0) {
+      _menuItemBack.menuItemNext = menuItemTmp;
+  }
+  itemsCount++;
+  itemsCountTotal++;
+  currentItemNum = (itemsCount > 1) ? 1 : 0;
 }
 
 void GEMPage::setTitle(const char* title_) {
-    title = title_;
+  title = title_;
 }
 
 const char* GEMPage::getTitle() {
-    return title;
+  return title;
 }
 
 GEMItem* GEMPage::getMenuItem(byte index, bool total) {
-    GEMItem* menuItemTmp = (_menuItem->hidden) ? _menuItem->getMenuItemNext() : _menuItem;
-    for (byte i=0; i<index; i++) {
-        menuItemTmp = (total) ? menuItemTmp->menuItemNext : menuItemTmp->getMenuItemNext();
-    }
-    return menuItemTmp;
+  GEMItem* menuItemTmp = (_menuItem->hidden) ? _menuItem->getMenuItemNext() : _menuItem;
+  for (byte i=0; i<index; i++) {
+      menuItemTmp = (total) ? menuItemTmp->menuItemNext : menuItemTmp->getMenuItemNext();
+  }
+  return menuItemTmp;
 }
 
 GEMItem* GEMPage::getCurrentMenuItem() {
-    return getMenuItem(currentItemNum);
+  return getMenuItem(currentItemNum);
 }
 
 int GEMPage::getMenuItemNum(GEMItem& menuItem) {
-    GEMItem* menuItemTmp = (_menuItem->hidden) ? _menuItem->getMenuItemNext() : _menuItem;
-    for (byte i=0; i<itemsCount; i++) {
-        if (menuItemTmp == &menuItem) {
-            return i;
-        }
-        menuItemTmp = menuItemTmp->getMenuItemNext();
-    }
-    return -1;
+  GEMItem* menuItemTmp = (_menuItem->hidden) ? _menuItem->getMenuItemNext() : _menuItem;
+  for (byte i=0; i<itemsCount; i++) {
+      if (menuItemTmp == &menuItem) {
+          return i;
+      }
+      menuItemTmp = menuItemTmp->getMenuItemNext();
+  }
+  return -1;
 }
 
 void GEMPage::hideMenuItem(GEMItem& menuItem) {
-    int menuItemNum = getMenuItemNum(menuItem);
-    menuItem.hidden = true;
-    itemsCount--;
-    if (menuItemNum <= currentItemNum) {
-        if (currentItemNum > 0) {
-            currentItemNum--;
-        }
-    }
-    if (_menuItemBack.linkedPage != nullptr && itemsCount == 1) {
-        currentItemNum = 0;
-    }
+  int menuItemNum = getMenuItemNum(menuItem);
+  menuItem.hidden = true;
+  itemsCount--;
+  if (menuItemNum <= currentItemNum) {
+      if (currentItemNum > 0) {
+          currentItemNum--;
+      }
+  }
+  if (_menuItemBack.linkedPage != nullptr && itemsCount == 1) {
+      currentItemNum = 0;
+  }
 }
 
 void GEMPage::showMenuItem(GEMItem& menuItem) {
-    int menuItemNum = getMenuItemNum(menuItem);
-    menuItem.hidden = false;
-    itemsCount++;
-    if (menuItemNum < currentItemNum) {
-        if (currentItemNum < itemsCount-1) {
-            currentItemNum++;
-        }
-    }
-    if (_menuItemBack.linkedPage != nullptr && itemsCount > 1) {
-        currentItemNum = 1;
-    }
+  int menuItemNum = getMenuItemNum(menuItem);
+  menuItem.hidden = false;
+  itemsCount++;
+  if (menuItemNum < currentItemNum) {
+      if (currentItemNum < itemsCount-1) {
+          currentItemNum++;
+      }
+  }
+  if (_menuItemBack.linkedPage != nullptr && itemsCount > 1) {
+      currentItemNum = 1;
+  }
 }

--- a/src/GEMPage.h
+++ b/src/GEMPage.h
@@ -40,21 +40,22 @@
 
 // Declaration of GEMPage class
 class GEMPage {
-  friend class GEM;
-  friend class GEM_u8g2;
-  friend class GEMItem;
-  public:
+    friend class GEM;
+    friend class GEM_u8g2;
+    friend class GEMItem;
+   public:
     /* 
       @param 'title_' - title of the menu page displayed at top of the screen
       @param 'exitAction_' - pointer to callback function executed when GEM_KEY_CANCEL is pressed while being on top level menu page
     */
-    GEMPage(char* title_ = "", void (*exitAction_)() = nullptr);
+    GEMPage(const char* title_ = "", void (*exitAction_)() = nullptr);
+    GEMPage(const __FlashStringHelper* title_ = F(""), void (*exitAction_)() = nullptr);
     void addMenuItem(GEMItem& menuItem);              // Add menu item to menu page
     void setParentMenuPage(GEMPage& parentMenuPage);  // Specify parent level menu page (to know where to go back to when pressing Back button)
-    void setTitle(char* title_);                      // Set title of the menu page
-    char* getTitle();                                 // Get title of the menu page
-  private:
-    char* title;
+    void setTitle(const char* title_);                // Set title of the menu page
+    const char* getTitle();                           // Get title of the menu page
+   private:
+    const char* title;
     byte currentItemNum = 0;                          // Currently selected (focused) menu item of the page
     byte itemsCount = 0;                              // Items count excluding hidden ones
     byte itemsCountTotal = 0;                         // Items count incuding hidden ones
@@ -68,5 +69,5 @@ class GEMPage {
                                                                 // setParentMenuPage(); always becomes the first menu item in a list)
     void (*exitAction)();
 };
-  
+
 #endif

--- a/src/GEMPage.h
+++ b/src/GEMPage.h
@@ -41,10 +41,10 @@
 
 // Declaration of GEMPage class
 class GEMPage {
-    friend class GEM;
-    friend class GEM_u8g2;
-    friend class GEMItem;
-   public:
+  friend class GEM;
+  friend class GEM_u8g2;
+  friend class GEMItem;
+  public:
     /* 
       @param 'title_' - title of the menu page displayed at top of the screen
       @param 'exitAction_' - pointer to callback function executed when GEM_KEY_CANCEL is pressed while being on top level menu page
@@ -55,7 +55,7 @@ class GEMPage {
     void setParentMenuPage(GEMPage& parentMenuPage);  // Specify parent level menu page (to know where to go back to when pressing Back button)
     void setTitle(const char* title_);                // Set title of the menu page
     const char* getTitle();                           // Get title of the menu page
-   private:
+  private:
     const char* title;
     byte currentItemNum = 0;                          // Currently selected (focused) menu item of the page
     byte itemsCount = 0;                              // Items count excluding hidden ones
@@ -70,5 +70,5 @@ class GEMPage {
                                                                 // setParentMenuPage(); always becomes the first menu item in a list)
     void (*exitAction)();
 };
-
+  
 #endif

--- a/src/GEMPage.h
+++ b/src/GEMPage.h
@@ -35,6 +35,7 @@
 #ifndef HEADER_GEMPAGE
 #define HEADER_GEMPAGE
 
+#include <WString.h>     // for __FlashStringHelper (F("asd"))
 #include <Arduino.h>
 #include "GEMItem.h"
 

--- a/src/GEM_u8g2.cpp
+++ b/src/GEM_u8g2.cpp
@@ -790,7 +790,7 @@ void GEM_u8g2::saveEditValue() {
       *(byte*)menuItemTmp->linkedVariable = atoi(_valueString);
       break;
     case GEM_VAL_CHAR:
-      strcpy((const char*)menuItemTmp->linkedVariable, trimString(_valueString)); // Potential overflow if string length is not defined
+      strcpy((char*)menuItemTmp->linkedVariable, trimString(_valueString)); // Potential overflow if string length is not defined
       break;
     case GEM_VAL_SELECT:
       {
@@ -827,7 +827,7 @@ void GEM_u8g2::exitEditValue() {
 
 // Trim leading/trailing whitespaces
 // Author: Adam Rosenfield, https://stackoverflow.com/a/122721
-char* GEM_u8g2::trimString(const char* str) {
+char* GEM_u8g2::trimString(char* str) {
   char *end;
 
   // Trim leading space

--- a/src/GEM_u8g2.cpp
+++ b/src/GEM_u8g2.cpp
@@ -240,7 +240,7 @@ void GEM_u8g2::drawTitleBar() {
  _u8g2.setFont(_menuItemFontSize ? _fontFamilies.small : _fontFamilies.big);
 }
 
-void GEM_u8g2::printMenuItemString(char* str, byte num, byte startPos) {
+void GEM_u8g2::printMenuItemString(const char* str, byte num, byte startPos) {
   if (_cyrillicEnabled) {
 
     byte j = 0;
@@ -274,11 +274,11 @@ void GEM_u8g2::printMenuItemString(char* str, byte num, byte startPos) {
   }
 }
 
-void GEM_u8g2::printMenuItemTitle(char* str, int offset) {
+void GEM_u8g2::printMenuItemTitle(const char* str, int offset) {
   printMenuItemString(str, _menuItemTitleLength + offset);
 }
 
-void GEM_u8g2::printMenuItemValue(char* str, int offset, byte startPos) {
+void GEM_u8g2::printMenuItemValue(const char* str, int offset, byte startPos) {
   printMenuItemString(str, _menuItemValueLength + offset, startPos);
 }
 
@@ -302,7 +302,7 @@ void GEM_u8g2::printMenuItemValue(GEMItem* menuItemTmp, byte yDraw)
         printMenuItemValue(valueStringTmp);
       break;
     case GEM_VAL_CHAR:
-        printMenuItemValue((char*)menuItemTmp->linkedVariable);
+        printMenuItemValue((const char*)menuItemTmp->linkedVariable);
       break;
     case GEM_VAL_BOOL:
       if (*(bool*)menuItemTmp->linkedVariable) {
@@ -335,7 +335,7 @@ void GEM_u8g2::printMenuItemValue(GEMItem* menuItemTmp, byte yDraw)
   memset(valueStringTmp, '\0', GEM_STR_LEN - 1);
 }
 
-void GEM_u8g2::printMenuItemFull(char* str, int offset) {
+void GEM_u8g2::printMenuItemFull(const char* str, int offset) {
   printMenuItemString(str, _menuItemTitleLength + _menuItemValueLength + offset);
 }
 
@@ -547,7 +547,7 @@ void GEM_u8g2::enterEditValueMode() {
       initEditValueCursor();
       break;
     case GEM_VAL_CHAR:
-      strcpy(_valueString, (char*)menuItemTmp->linkedVariable);
+      strcpy(_valueString, (const char*)menuItemTmp->linkedVariable);
       _editValueLength = GEM_STR_LEN - 1;
       initEditValueCursor();
       break;
@@ -790,7 +790,7 @@ void GEM_u8g2::saveEditValue() {
       *(byte*)menuItemTmp->linkedVariable = atoi(_valueString);
       break;
     case GEM_VAL_CHAR:
-      strcpy((char*)menuItemTmp->linkedVariable, trimString(_valueString)); // Potential overflow if string length is not defined
+      strcpy((const char*)menuItemTmp->linkedVariable, trimString(_valueString)); // Potential overflow if string length is not defined
       break;
     case GEM_VAL_SELECT:
       {
@@ -827,7 +827,7 @@ void GEM_u8g2::exitEditValue() {
 
 // Trim leading/trailing whitespaces
 // Author: Adam Rosenfield, https://stackoverflow.com/a/122721
-char* GEM_u8g2::trimString(char* str) {
+char* GEM_u8g2::trimString(const char* str) {
   char *end;
 
   // Trim leading space

--- a/src/GEM_u8g2.h
+++ b/src/GEM_u8g2.h
@@ -157,11 +157,11 @@ class GEM_u8g2 {
     GEMItem* _menuItemCurrent;
     void layoutMenu();
     void drawTitleBar();
-    void printMenuItemString(char* str, byte num, byte startPos = 0);
-    void printMenuItemTitle(char* str, int offset = 0);
-    void printMenuItemValue(char* str, int offset = 0, byte startPos = 0);
+    void printMenuItemString(const char* str, byte num, byte startPos = 0);
+    void printMenuItemTitle(const char* str, int offset = 0);
+    void printMenuItemValue(const char* str, int offset = 0, byte startPos = 0);
     void printMenuItemValue(GEMItem* menuItemTmp, byte yDraw);
-    void printMenuItemFull(char* str, int offset = 0);
+    void printMenuItemFull(const char* str, int offset = 0);
     byte getMenuItemInsetOffset(bool forSprite = false);
     byte getCurrentItemTopOffset(bool withInsetOffset = true, bool forSprite = false);
     void printMenuItems();


### PR DESCRIPTION
Changed `char*` to `const char*`  to get rid of compiler warnings since we use `const char*` in the constructor calls (by providing a const string like "Einstellungen").  
Added support for `__FlashStringHelper` to be able to provide strings that are located in PROGMEM (e.g. FLASH) instead of using variables that are stored in RAM. You can use this, by adding a `F()` macro around your const strings (e.g. `F("PageTitle")`).